### PR TITLE
fix: token error on instance creation

### DIFF
--- a/cs2/app/functions/instance.sh
+++ b/cs2/app/functions/instance.sh
@@ -41,7 +41,7 @@ EOF
 
 
 App::finalizeInstance () (
-	[[ $INSTANCE_DIR -ne $INSTALL_DIR ]] && {
+	[[ "$INSTANCE_DIR" != "$INSTALL_DIR" ]] && {
 		# Make sure each instance has its own up-to-date cs2 binary
 		rm "$INSTANCE_DIR/$SERVER_EXEC"
 		cp "$INSTALL_DIR/$SERVER_EXEC" "$INSTANCE_DIR/$SERVER_EXEC"


### PR DESCRIPTION
To fix this issue:

```sh
Finishing instance creation ...
/home/steam/cs2-multiserver/cs2/app/functions/instance.sh: line 44: [[: /home/steam/msm.d/cs2/inst-prac01: syntax error: operand expected (error token is "/home/steam/msm.d/cs2/inst-prac01")
**SUCCESS:** in Core.Instance::create                        ( 252)
             in ~~ @prac01 ~~ Core.CommandLine::exec         ( 156)
    Instance created successfully!

    Now, edit your instance's configuration files, located in
    **/home/steam/msm.d/cs2/cfg/inst-prac01**, to set IP, port,
    passwords and other game settings of your instance.
```

Then when I was running my new instance, only the base files were used.

Now working perfectly, using the instance files (fixed my metamod/css issues too):

```sh
Finishing instance creation ...
**SUCCESS:** in Core.Instance::create                        ( 252)
             in ~~ @prac02 ~~ Core.CommandLine::exec         ( 156)
    Instance created successfully!

    Now, edit your instance's configuration files, located in
    **/home/steam/msm.d/cs2/cfg/inst-prac02**, to set IP, port,
    passwords and other game settings of your instance.
```