### PR TITLE
Backslashes properly escaped

### DIFF
--- a/program/Core/Server/functions.sh
+++ b/program/Core/Server/functions.sh
@@ -177,11 +177,18 @@ Core.Server::sendCommand () {
 			error <<< "**$INSTANCE_TEXT** is not running!"
 			return
 		}
-
-		local args="$(quote "$@")"
+		# Process escaped quotes
+		local args=""
+		local arg
+		for arg in "$@"; do
+			# Replace \" with "
+			arg="${arg//\\\"/\"}"
+			args+="$arg "
+		done
+		args="${args% }"  # Remove trailing space
+		
 		log <<< "Sending the following command to $INSTANCE_TEXT:"
 		log <<< "    $args"
-
 		echo "$args" | tmux-send -t ":$APP-server"
 	fi
 }


### PR DESCRIPTION
This is to fix issue #50 so that backslashes can properly escape double quotes from being stripped, for commands that need double quotes.

Before:
```
$ cs2-server @game1 exec echo \"test\"

Sending the following command to Instance @game1:
    echo \"test\"
```

Now:
```
$ cs2-server @game1 exec echo \"test\"

Sending the following command to Instance @game1:
    echo "test"
```